### PR TITLE
Allow 'lead' users to admins also fixed summary bug

### DIFF
--- a/client/src/pages/Admin.jsx
+++ b/client/src/pages/Admin.jsx
@@ -31,7 +31,7 @@ const Admin = () => {
 };
 
 const checkAdmin = (user) => {
-  return user.email.split("@")[0] === "admin";
+  return user.email.split("@")[0] === "admin" || user.email.split("@")[0] === "lead";
 };
 
 export default Admin;

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -33,8 +33,8 @@ const Dashboard = () => {
   );
 };
 
-export const checkAdmin = (user) => {
-  return user.email.split("@")[0] === "admin";
+const checkAdmin = (user) => {
+  return user.email.split("@")[0] === "admin" || user.email.split("@")[0] === "lead";
 };
 
 export default Dashboard;

--- a/client/src/pages/adminpages/AISummarization.jsx
+++ b/client/src/pages/adminpages/AISummarization.jsx
@@ -253,6 +253,8 @@ No climb: ${none}
 
     let summarized = await summarize(reports);
 
+    summarized.overall_rating = parseInt(summarized.overall_rating.split("/")[0]);
+
     let schema = await getActiveSchema().then((schema) => schema.name);
     updateTeamAISummarize(summarized, team, schema);
 
@@ -583,7 +585,7 @@ No climb: ${none}
 };
 
 const checkAdmin = (user) => {
-  return user.email.split("@")[0] === "admin";
+  return user.email.split("@")[0] === "admin" || user.email.split("@")[0] === "lead";
 };
 
 export default AISummarization;

--- a/client/src/pages/adminpages/ConfigureAnalysis.jsx
+++ b/client/src/pages/adminpages/ConfigureAnalysis.jsx
@@ -96,7 +96,7 @@ const ConfigureAnalysis = () => {
 };
 
 const checkAdmin = (user) => {
-    return user.email.split("@")[0] === "admin";
+    return user.email.split("@")[0] === "admin" || user.email.split("@")[0] === "lead";
 };
 
 export default ConfigureAnalysis;

--- a/client/src/pages/adminpages/ConfigureSchema.jsx
+++ b/client/src/pages/adminpages/ConfigureSchema.jsx
@@ -89,7 +89,7 @@ const ConfigureSchema = () => {
 };
 
 const checkAdmin = (user) => {
-    return user.email.split("@")[0] === "admin";
+    return user.email.split("@")[0] === "admin" || user.email.split("@")[0] === "lead";
 };
 
 export default ConfigureSchema;

--- a/client/src/pages/adminpages/ManageUsers.jsx
+++ b/client/src/pages/adminpages/ManageUsers.jsx
@@ -146,7 +146,7 @@ const ManageUsers = () => {
 };
 
 const checkAdmin = (user) => {
-  return user.email.split("@")[0] === "admin";
+  return user.email.split("@")[0] === "admin" || user.email.split("@")[0] === "lead";
 };
 
 export default ManageUsers;


### PR DESCRIPTION
This pull request includes changes to the `client/src/pages` directory to enhance the admin check functionality and improve data processing in the `AISummarization` page. The most important changes are as follows:

Enhancements to admin check functionality:

* [`client/src/pages/Admin.jsx`](diffhunk://#diff-47048429fd7f9cb32b6728fc1ad03098cb12c788f4778787316289d5c33d453dL34-R34): Updated `checkAdmin` function to include users with "lead" in their email prefix.
* [`client/src/pages/Dashboard.jsx`](diffhunk://#diff-2e300b20a08d42aeed23fc567c825cae220086261cb362a1481eb786ea762d4aL36-R37): Moved `checkAdmin` function inside the component and updated it to include "lead" in the email prefix.
* [`client/src/pages/adminpages/AISummarization.jsx`](diffhunk://#diff-87e0b001a2094156863084e65947b6ace99db83fa9c0199c9e7a980ea714fee8L586-R588): Updated `checkAdmin` function to include users with "lead" in their email prefix.
* [`client/src/pages/adminpages/ConfigureAnalysis.jsx`](diffhunk://#diff-dbdc5be4b607aef2497e0cf2061e42e7f2f5ddaae345af84ac3f68cba2b70bd0L99-R99): Updated `checkAdmin` function to include users with "lead" in their email prefix.
* [`client/src/pages/adminpages/ConfigureSchema.jsx`](diffhunk://#diff-6d6852f0d0aef98aecce84c488eec0518e52557eb98b95acac29e91a097243c2L92-R92): Updated `checkAdmin` function to include users with "lead" in their email prefix.
* [`client/src/pages/adminpages/ManageUsers.jsx`](diffhunk://#diff-ed3ff3627089cd4cfb90e7efabd5b84c83c4c030f01906aee1083df0ffa61174L149-R149): Updated `checkAdmin` function to include users with "lead" in their email prefix.

Data processing improvement:

* [`client/src/pages/adminpages/AISummarization.jsx`](diffhunk://#diff-87e0b001a2094156863084e65947b6ace99db83fa9c0199c9e7a980ea714fee8R256-R257): Added parsing of `overall_rating` to ensure it is an integer.